### PR TITLE
replにヒストリ機能を追加

### DIFF
--- a/files.mk
+++ b/files.mk
@@ -1053,6 +1053,7 @@ MINISMLSHARP_OBJECTS = src/compiler/minismlsharp.o \
 src/compiler/main/main/SimpleMain.o \
 src/compiler/main/main/ExecutablePath.o \
 src/compiler/main/main/RunLoop.o \
+src/compiler/main/main/Repl.o \
 src/sql/main/SQLPrim.o \
 src/sql/main/Backend.o \
 src/sql/main/PGSQLBackend.o \
@@ -1328,6 +1329,7 @@ src/compiler/minismlsharp.sml \
 src/compiler/main/main/SimpleMain.sml \
 src/compiler/main/main/ExecutablePath.sml \
 src/compiler/main/main/RunLoop.sml \
+src/compiler/main/main/Repl.sml \
 src/sql/main/SQLPrim.sml \
 src/sql/main/Backend.sml \
 src/sql/main/PGSQLBackend.sml \
@@ -1690,6 +1692,7 @@ COMPILER_LIB_OBJECTS = src/compiler/smlsharp.o \
 src/compiler/main/main/SimpleMain.o \
 src/compiler/main/main/ExecutablePath.o \
 src/compiler/main/main/RunLoop.o \
+src/compiler/main/main/Repl.o \
 src/compiler/main/main/SMLofNJ.o \
 src/compiler/main/main/GetOpt.o \
 src/compiler/toplevel2/main/Top.o \
@@ -1967,6 +1970,7 @@ src/compiler/smlsharp.sml \
 src/compiler/main/main/SimpleMain.sml \
 src/compiler/main/main/ExecutablePath.sml \
 src/compiler/main/main/RunLoop.sml \
+src/compiler/main/main/Repl.sml \
 src/compiler/main/main/SMLofNJ.sml \
 src/compiler/main/main/GetOpt.sml \
 src/compiler/toplevel2/main/Top.sml \
@@ -3013,6 +3017,8 @@ src/compiler/main/main/GetOpt.o \
 src/compiler/main/main/GetOpt.smi \
 src/compiler/main/main/RunLoop.o \
 src/compiler/main/main/RunLoop.smi \
+src/compiler/main/main/Repl.o \
+src/compiler/main/main/Repl.smi \
 src/compiler/main/main/SMLofNJ.o \
 src/compiler/main/main/SMLofNJ.smi \
 src/compiler/main/main/SimpleMain.o \
@@ -3503,6 +3509,7 @@ src/compiler/loadfile/main/SHA1.o \
 src/compiler/main/main/ExecutablePath.o \
 src/compiler/main/main/GetOpt.o \
 src/compiler/main/main/RunLoop.o \
+src/compiler/main/main/Repl.o \
 src/compiler/main/main/SMLofNJ.o \
 src/compiler/main/main/SimpleMain.o \
 src/compiler/matchcompilation/main/MatchCompiler.o \

--- a/src/compiler/main/main/Repl.smi
+++ b/src/compiler/main/main/Repl.smi
@@ -1,0 +1,6 @@
+_require "../../../basis.smi"
+
+structure Repl = struct
+  val inputLine : string -> string option
+  val homePath : string -> string
+end

--- a/src/compiler/main/main/Repl.sml
+++ b/src/compiler/main/main/Repl.sml
@@ -1,0 +1,134 @@
+structure Repl = struct
+
+  val memhist:string list ref = ref []
+
+  fun readHistory(s:string) = (
+    if(s<>"") then
+      let
+        val in1 = TextIO.openIn(s)
+        fun read(l) =
+          case TextIO.inputLine(in1) of
+            NONE => l
+          | SOME(s) => read(substring(s,0,(size s) - 1)::l)
+        val rc = read([])
+      in
+        TextIO.closeIn(in1);
+        rc
+      end handle Io => []
+    else !memhist
+  )
+
+  fun writeHistory(s:string,l) =
+    if(s<>"") then
+      let
+        val out1 = TextIO.openAppend(s)
+      in
+        TextIO.output(out1, l ^ "\n");
+        TextIO.closeOut(out1)
+      end handle Io => ()
+    else (
+      memhist := l :: !memhist
+    )
+
+  fun getchar():char = (
+    case TextIO.input1(TextIO.stdIn) of
+      SOME(c) => c
+    |  NONE => getchar()
+  )
+
+  fun tstr(str,n) =
+  let
+    fun f(n,r) = if(n<=0) then r else f(n-1,r ^ str)
+  in
+    f(n,"")
+  end
+
+  fun inputLine(file) =
+  let
+    fun update(l,n,item) =
+    let
+      fun f(h,l,i) =
+        if i = n then (rev h) @ item::(tl l)
+        else f((hd l)::h,(tl l),i+1)
+    in
+      f([],l,0)
+    end
+
+    fun loop(src,p,hs1,h) =
+    let
+      val hs = update(hs1, h, src)
+      fun hist(h) = (
+        let
+          val src2 = List.nth(hs, h)
+          val dellen = (size src) - (size src2)
+        in
+          print(tstr("\^[[D", p));
+          print(src2);
+          print(tstr(" ", dellen));
+          print(tstr("\^[[D", dellen));
+          loop(src2, size src2,hs,h)
+        end
+      )
+    in
+      case getchar() of
+          #"\n" => (print("\n"); src)
+        | #"\t" => loop(src, p, hs, h)
+        | #"\^[" => (
+          (* escape *)
+          getchar();
+          case getchar() of
+              #"A" => (* up *)
+                if(h < length(hs)-1)
+                then hist(h+1)
+                else loop(src,p,hs,h)
+            | #"B" => (* down *)
+                if(h > 0)
+                then hist(h-1)
+                else loop(src,p,hs,h)
+            | #"D" => (* left *)
+                if (p > 0)
+                then (print("\^[[D"); loop(src,p-1,hs,h))
+                else loop(src,p,hs,h)
+            | #"C" => (* right *)
+                if (p < size src)
+                then (print("\^[[C"); loop(src,p+1,hs,h))
+                else loop(src,p,hs,h)
+            | c => (print ("####"^str(c)^"####"); loop(src,p,hs,h))
+        )
+        | #"\127" => (* delete *)
+          if (src <> "" andalso p > 0) then
+            (let
+              val src1 = substring(src,0,p - 1) 
+              val src2len = (size src) - p
+              val src2 = substring(src,p,src2len)
+            in
+              print("\^[[D");
+              print(src2 ^ " ");
+              print(tstr("\^[[D", src2len + 1));
+              loop(src1 ^ src2, p - 1, hs, h)
+            end)
+          else loop(src,p,hs,h)
+        | c => (* insert *)
+          let
+            val src1 = substring(src,0,p)
+            val src2len = (size src) - p
+            val src2 = substring(src,p,src2len)
+          in
+            print(str(c) ^ src2);
+            print(tstr("\^[[D", src2len));
+            loop(src1 ^ str(c) ^ src2, p + 1, hs, h)
+          end
+    end
+    val _ = OS.Process.system("stty -echo -icanon min 1 time 0");
+    val rc = loop("",0,""::readHistory(file),0)
+    val _ = writeHistory(file, rc)
+    val _ = OS.Process.system("stty echo -icanon min 1 time 0")
+  in
+    SOME(rc)
+  end
+
+  fun homePath(f) = 
+    case OS.Process.getEnv("HOME") of
+      SOME(e) => e ^ "/" ^ f
+      | NONE => ""
+end

--- a/src/compiler/main/main/Repl.sml
+++ b/src/compiler/main/main/Repl.sml
@@ -123,8 +123,9 @@ structure Repl = struct
     val rc = loop("",0,""::readHistory(file),0)
     val _ = writeHistory(file, rc)
     val _ = OS.Process.system("stty echo -icanon min 1 time 0")
+    val rc2 = rc ^ "\n"
   in
-    SOME(rc)
+    if(rc2="") then NONE else SOME(rc2)
   end
 
   fun homePath(f) = 

--- a/src/compiler/main/main/RunLoop.smi
+++ b/src/compiler/main/main/RunLoop.smi
@@ -14,6 +14,7 @@ _require "../../toplevel2/main/Top.smi"
 _require "../../../config/main/Config.smi"
 _require "../../../config/main/Version.smi"
 _require "../../../sql/main/SQLPrim.smi"
+_require "Repl.smi"
 
 structure RunLoop =
 struct

--- a/src/compiler/main/main/RunLoop.sml
+++ b/src/compiler/main/main/RunLoop.sml
@@ -206,8 +206,11 @@ struct
               val prompt = if isFirst then "# " else "> "
               val _ = TextIO.output (TextIO.stdOut, prompt)
               val _ = TextIO.flushOut TextIO.stdOut
+
 (*              val line = TextIO.inputLine TextIO.stdIn*)
-              val line = Repl.inputLine(Repl.homePath ".sml_history")
+              val line = case !SMLSharp_Version.HostOS of
+                  SMLSharp_Version.Unix => Repl.inputLine(Repl.homePath ".sml_history")
+                | SMLSharp_Version.Windows => TextIO.inputLine TextIO.stdIn
               val _ = lineCount := !lineCount + 1
             in
               case line of NONE => (eof := true; "") | SOME s => s

--- a/src/compiler/main/main/RunLoop.sml
+++ b/src/compiler/main/main/RunLoop.sml
@@ -206,7 +206,8 @@ struct
               val prompt = if isFirst then "# " else "> "
               val _ = TextIO.output (TextIO.stdOut, prompt)
               val _ = TextIO.flushOut TextIO.stdOut
-              val line = TextIO.inputLine TextIO.stdIn
+(*              val line = TextIO.inputLine TextIO.stdIn*)
+              val line = Repl.inputLine(Repl.homePath ".sml_history")
               val _ = lineCount := !lineCount + 1
             in
               case line of NONE => (eof := true; "") | SOME s => s


### PR DESCRIPTION
TextIO.inputLineを
Repl.inputLineに変更するとヒストリ機能を組み込めるようにして組み込みました。

main/main/Repl.sml, main/main/Repl.smiを追加して、
main/main/RunLoop.smlで呼び出しています。

~/.sml_history
に履歴が保存されるようにして、カーソルキーの上下でヒストリの参照、
カーソルキーの右左で移動して書き換えが出来るようにしてみました。
Mac OSX Lion でのみ確認済みで、Unixなら動くと思います。

Windowsはどうしようというところです。とりあえず何もしてませんが
とりあえず、切っておいて、対応できたらONにすればいいのかもしれません。

Pull Requestは初めてなのですが、よろしくお願いします。
