### PR TITLE
Add missing newline in smlsharp command-line help text

### DIFF
--- a/src/compiler/compilePhases/main/main/Main.sml
+++ b/src/compiler/compilePhases/main/main/Main.sml
@@ -256,7 +256,7 @@ struct
       \  -fsyntax-only      check for syntax errors, and exit\n\
       \  -ftypecheck-only   check for type errors, and exit\n\
       \  -filemap=<file>    specify a map from interface files to object files\n\
-      \  -r <file>          add a library preloaded in interactive mode\
+      \  -r <file>          add a library preloaded in interactive mode\n\
       \  -I <dir>           add <dir> to file search path\n\
       \  -L <dir>           add <dir> to library path of the linker\n\
       \  -l <libname>       link with <libname> to create an executable file\n\


### PR DESCRIPTION
This is a very small quality-of-life change in the `smlsharp` compiler command-line help text.

There was a missing newline in the text, which made it easy to miss the '-I' option when reading the output of `smlsharp --help`.


## Before

```
% smlsharp --help
Usage: smlsharp [options] file ...
Options:
  --help             print this message
  -v                 verbose mode
  -o <file>          place the output to <file>
  -c                 compile and assemble; do not link
  -S                 compile only; do not assemble and link
  -emit-llvm         emit LLVM code instead of native machine code
  -O[0-3]            set optimization level to 0-3
  -Os                optimize for code size
  -Oz                optimize for code size aggressively
  --target=<triple>  generate code for specified target
  -march=<arch>      target a specific architecture
  -mcpu=<cpu>        target a specific CPU type
  -mattr=<attrs,...> target specific attributes
  -mcmodel=<model>   set x86-64 code model (small, kernel, medium or large
  -fpic              generate position independent code if possible
  -fno-pic           don't generate position independent code
  -mdynamic-no-pic   generate absolute addressing code suitable for executables
  -A                 analyze a source file tree
  -M                 make dependency for compile
  -MM                make dependency for compile but ignore system files
  -Ml                make dependency for link
  -MMl               make dependency for link but ignore system files
  -c++               use C++ compiler driver as linker
  -fsyntax-only      check for syntax errors, and exit
  -ftypecheck-only   check for type errors, and exit
  -filemap=<file>    specify a map from interface files to object files
  -r <file>          add a library preloaded in interactive mode  -I <dir>           add <dir> to file search path
  -L <dir>           add <dir> to library path of the linker
  -l <libname>       link with <libname> to create an executable file
  -Wl,<args>         pass comma-separated <args> to the linker
  -Xlinker <arg>     pass <arg> to the linker
  -Xllc <arg>        pass <arg> to llc command
  -Xopt <arg>        pass <arg> to opt command
  -nostdpath         no standard file search path is used
  -d <key>=<value>   set extra option for compiler developers
  -d                 turn on developer mode
  -d --help          print list of extra options
  
```

## After

```
]% ./src/compiler/smlsharp --help
Usage: ./src/compiler/smlsharp [options] file ...
Options:
  --help             print this message
  -v                 verbose mode
  -o <file>          place the output to <file>
  -c                 compile and assemble; do not link
  -S                 compile only; do not assemble and link
  -emit-llvm         emit LLVM code instead of native machine code
  -O[0-3]            set optimization level to 0-3
  -Os                optimize for code size
  -Oz                optimize for code size aggressively
  --target=<triple>  generate code for specified target
  -march=<arch>      target a specific architecture
  -mcpu=<cpu>        target a specific CPU type
  -mattr=<attrs,...> target specific attributes
  -mcmodel=<model>   set x86-64 code model (small, kernel, medium or large
  -fpic              generate position independent code if possible
  -fno-pic           don't generate position independent code
  -mdynamic-no-pic   generate absolute addressing code suitable for executables
  -A                 analyze a source file tree
  -M                 make dependency for compile
  -MM                make dependency for compile but ignore system files
  -Ml                make dependency for link
  -MMl               make dependency for link but ignore system files
  -c++               use C++ compiler driver as linker
  -fsyntax-only      check for syntax errors, and exit
  -ftypecheck-only   check for type errors, and exit
  -filemap=<file>    specify a map from interface files to object files
  -r <file>          add a library preloaded in interactive mode
  -I <dir>           add <dir> to file search path
  -L <dir>           add <dir> to library path of the linker
  -l <libname>       link with <libname> to create an executable file
  -Wl,<args>         pass comma-separated <args> to the linker
  -Xlinker <arg>     pass <arg> to the linker
  -Xllc <arg>        pass <arg> to llc command
  -Xopt <arg>        pass <arg> to opt command
  -nostdpath         no standard file search path is used
  -d <key>=<value>   set extra option for compiler developers
  -d                 turn on developer mode
  -d --help          print list of extra options
```

