### PR TITLE
OS structure conforms to OS signature

### DIFF
--- a/src/basis/main/SMLSharp_OSIO.smi
+++ b/src/basis/main/SMLSharp_OSIO.smi
@@ -7,7 +7,7 @@ _require       "./Word8VectorSlice.smi"
 
 structure SMLSharp_OSIO =
 struct
-  type iodesc (= int)
+  eqtype iodesc (= int)
   val hash : iodesc -> word
   val compare : iodesc * iodesc -> General.order
   eqtype iodesc_kind (= word)


### PR DESCRIPTION
Right now, the `OS` structure in the basis library does not seem to conform to the `OS` signature:

```
# structure OS : OS = OS;
/usr/local/lib/smlsharp/basis/main/OS.smi:46.9(1753)-46.14(1758) Error:
  (name evaluation "200") Signature mismatch. eqtype expected: OS.IO.iodesc
```

Changing the `iodesc` type in structure `SMLSharp_OSIO` into an eqtype fixes this