### PR TITLE
Add support for newer LLVM versions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -218,7 +218,7 @@ AC_MSG_CHECKING([for LLVM compatibility])
 LLVM_VERSION=`echo "$LLVM_VERSION" | sed 's/\.[[0-9]]*$//'`
 AC_SUBST(LLVM_VERSION)
 case "$LLVM_VERSION" in
-  3.9|[[4-9]].0|1[[0-1]].0|11.1|12.0|13.0)
+  3.9|[[4-9]].0|1[[0-7]].0|11.1|18.1)
     AC_MSG_RESULT(yes)
     ;;
   *)


### PR DESCRIPTION
This should make distro maintainers lives easier for another year or so. Support extended all the way up to LLVM18.
No new test failures when compiling with llvm18.1 on my machine. Also tested 16, 14, and also 10 as the 'control group'.