### PR TITLE
Newer llvm support with New IR 

### DIFF
--- a/configure
+++ b/configure
@@ -5342,7 +5342,7 @@ $as_echo_n "checking for LLVM compatibility... " >&6; }
 LLVM_VERSION=`echo "$LLVM_VERSION" | sed 's/\.[0-9]*$//'`
 
 case "$LLVM_VERSION" in
-  3.9|[4-9].0|1[0-1].0|11.1|12.0|13.0|14.0)
+  3.9|[4-9].0|1[0-8].0|11.1|18.1)
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
     ;;

--- a/configure
+++ b/configure
@@ -5342,7 +5342,7 @@ $as_echo_n "checking for LLVM compatibility... " >&6; }
 LLVM_VERSION=`echo "$LLVM_VERSION" | sed 's/\.[0-9]*$//'`
 
 case "$LLVM_VERSION" in
-  3.9|[4-9].0|1[0-1].0|11.1|12.0|13.0)
+  3.9|[4-9].0|1[0-1].0|11.1|12.0|13.0|14.0)
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
     ;;

--- a/configure.ac
+++ b/configure.ac
@@ -218,7 +218,7 @@ AC_MSG_CHECKING([for LLVM compatibility])
 LLVM_VERSION=`echo "$LLVM_VERSION" | sed 's/\.[[0-9]]*$//'`
 AC_SUBST(LLVM_VERSION)
 case "$LLVM_VERSION" in
-  3.9|[[4-9]].0|1[[0-1]].0|11.1|12.0|13.0)
+  3.9|[[4-9]].0|1[[0-1]].0|11.1|12.0|13.0|14.0)
     AC_MSG_RESULT(yes)
     ;;
   *)

--- a/configure.ac
+++ b/configure.ac
@@ -218,7 +218,7 @@ AC_MSG_CHECKING([for LLVM compatibility])
 LLVM_VERSION=`echo "$LLVM_VERSION" | sed 's/\.[[0-9]]*$//'`
 AC_SUBST(LLVM_VERSION)
 case "$LLVM_VERSION" in
-  3.9|[[4-9]].0|1[[0-1]].0|11.1|12.0|13.0|14.0)
+  3.9|[[4-9]].0|1[[0-8]].0|11.1|18.1)
     AC_MSG_RESULT(yes)
     ;;
   *)

--- a/src/compiler/compilePhases/toplevel/main/Top.sml
+++ b/src/compiler/compilePhases/toplevel/main/Top.sml
@@ -719,6 +719,11 @@ struct
                      then doInsertCheckGC mccalc
                      else mccalc
         val mccalc = doStackAllocation mccalc
+
+        (*get LLVM version from commands and set version to IR Dumper *)
+        val ir_version = LLVMUtils.getIRVersion ()
+        val _ = LLVMIR.version_of_ir := ir_version
+
         val llvmir = doLLVMGen llvmOptions (prelude, mccalc)
         val llfile = doLLVMEmit llvmir
         val bcfile = doAssemble llfile

--- a/src/compiler/compilerIRs/llvmir/main/LLVMIR.ppg
+++ b/src/compiler/compilerIRs/llvmir/main/LLVMIR.ppg
@@ -6,6 +6,20 @@
 structure LLVMIR =
 struct
 
+  (* switch for LLVM IR dumper.*)
+  datatype ir_version =
+      IR14Early (* LLVM 14 or earlier *)
+    | IR15 (* LLVM 15 opaque pointer.*)
+    | IR16_17_18_19 (* function attribute change. let see LLVM 16 manual *)
+
+  val version_of_ir = ref IR14Early
+
+  fun versioned_fmt (ir14,ir15,ir19) version_of_ir =
+    case !version_of_ir of
+      IR14Early => ir14
+    | IR15 => ir15
+    | IR16_17_18_19 => ir19
+
   fun ifcons (x,y) (_::_) = x
     | ifcons (x,y) nil = y
   fun ifsome (x,y) (SOME _) = x
@@ -98,7 +112,9 @@ struct
     | (*% @format "nest" *)
       NEST
 
-  (*% *)
+  (*%
+   * @formatter(versioned_fmt) versioned_fmt
+  *)
   datatype function_attribute =
 (*
       (*% @format(n) "alignstack(" n ")" *)
@@ -135,9 +151,9 @@ struct
       NOUNWIND
     | (*% @format "optsize" *)
       OPTSIZE
-    | (*% @format "readnone" *)
+    | (*% @format version_of_ir:versioned_fmt()("readnone","readnone","memory(none)") *)
       READNONE
-    | (*% @format "readonly" *)
+    | (*% @format version_of_ir:versioned_fmt()("readonly","readonly","memory(read)") *)
       READONLY
     | (*% @format "returns_twice" *)
       RETURNS_TWICE
@@ -187,6 +203,7 @@ struct
    * @formatter(Word32.word) word32Dec
    * @formatter(ifcons) ifcons
    * @formatter(iftrue) iftrue
+   * @formatter(versioned_fmt) versioned_fmt
    *)
   datatype ty =
       (*% @format "i1" *)
@@ -199,7 +216,7 @@ struct
       I32
     | (*% @format "i64" *)
       I64
-    | (*% @format(ty) ty "*" *)
+    | (*% @format(ty) version_of_ir:versioned_fmt()("*" ty,"ptr","ptr") *)
       PTR of ty 
     | (*% @format "float" *)
       FLOAT

--- a/src/compiler/compilerIRs/llvmir/main/LLVMIR.ppg
+++ b/src/compiler/compilerIRs/llvmir/main/LLVMIR.ppg
@@ -216,7 +216,7 @@ struct
       I32
     | (*% @format "i64" *)
       I64
-    | (*% @format(ty) version_of_ir:versioned_fmt()("*" ty,"ptr","ptr") *)
+    | (*% @format(ty) version_of_ir:versioned_fmt()(ty "*","ptr","ptr") *)
       PTR of ty 
     | (*% @format "float" *)
       FLOAT

--- a/src/compiler/compilerIRs/llvmir/main/LLVMIR.ppg.smi
+++ b/src/compiler/compilerIRs/llvmir/main/LLVMIR.ppg.smi
@@ -13,6 +13,14 @@ struct
   type var = VarID.id
   type symbol = string
 
+
+  datatype ir_version =
+      IR14Early (* LLVM 14 or earlier *)
+    | IR15 (* LLVM 15 opaque pointer.*)
+    | IR16_17_18_19 (* function attribute change. let see LLVM 16 manual *)
+
+  val version_of_ir : ir_version ref
+
   datatype calling_convention =
       CCC
     | FASTCC

--- a/src/compiler/libs/toolchain/main/LLVMUtils.smi
+++ b/src/compiler/libs/toolchain/main/LLVMUtils.smi
@@ -1,5 +1,6 @@
 _require local "../../../../basis.smi"
 _require local "../../../libs/config/main/Config.smi"
+_require "../../../compilerIRs/llvmir/main/LLVMIR.ppg.smi"
 (* _require local "../../../extensions/debug/main/Bug.smi" *)
 
 _require local "./CoreUtils.smi"
@@ -74,5 +75,5 @@ struct
 
   val getVersion : unit -> string
   val getDefaultTarget : unit -> string
-
+  val getIRVersion : unit -> LLVMIR.ir_version
 end

--- a/src/compiler/libs/toolchain/main/LLVMUtils.sml
+++ b/src/compiler/libs/toolchain/main/LLVMUtils.sml
@@ -5,7 +5,7 @@
  *)
 structure LLVMUtils =
 struct
-
+  exception UnsupportedVersion of string
   datatype arg = datatype ShellUtils.arg
 
   val ASMEXT = "ll"
@@ -65,10 +65,49 @@ struct
                     output = output}
        end
   in
+
+
   fun getVersion () =
       case !version of
         SOME x => x
       | NONE => #version (get ())
+
+  fun textToIRVersion versionText =
+    let
+      val version_numbers = String.tokens (fn #"."=> true
+      | _ =>false ) versionText
+      val major = List.nth (version_numbers,0)
+      val minor =  List.nth (version_numbers,1)
+    in
+      case (major,minor)  of
+        ("3","9") => LLVMIR.IR14Early
+      | ("4",_) => LLVMIR.IR14Early
+      | ("5",_) => LLVMIR.IR14Early
+      | ("6",_) => LLVMIR.IR14Early
+      | ("7",_) => LLVMIR.IR14Early
+      | ("8",_) => LLVMIR.IR14Early
+      | ("9",_) => LLVMIR.IR14Early
+      | ("10",_) => LLVMIR.IR14Early
+      | ("11",_) => LLVMIR.IR14Early
+      | ("12",_) => LLVMIR.IR14Early
+      | ("13",_ )=> LLVMIR.IR14Early
+      | ("14",_) => LLVMIR.IR14Early
+      | ("15",_) => LLVMIR.IR15
+      | ("16",_) => LLVMIR.IR16_17_18_19
+      | ("17",_) => LLVMIR.IR16_17_18_19
+      | ("18",_) => LLVMIR.IR16_17_18_19
+      | ("19",_) => LLVMIR.IR16_17_18_19
+      | (_,_)  => raise UnsupportedVersion versionText
+    end
+
+  fun getIRVersion () =
+     let val versionText = case !version of
+        SOME x => x
+        |None => #version (get ())
+      in
+        textToIRVersion versionText handle UnsupportedVersion _ => LLVMIR.IR14Early
+      end
+
   fun getDefaultTarget () =
       case !defaultTarget of
         "" => #target (get ())


### PR DESCRIPTION
LLVM 13 was removed from Ubuntu 24.04 LTS .
fortunately Mr.Iwamatsu maintain for debian with LLVM 14 support.  as a result smlsharp for ubuntu package exists.
but other newer LLVM versions may require complex patch for gc_plugin and anonymizer or LLVMIR.ppg .


